### PR TITLE
Remove R dependency deprecation dates

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,14 +2,6 @@
 language: r
 default_versions: []
 dependency_deprecation_dates:
-- version_line: 3.6.x
-  name: r
-  date: 2020-03-01
-  link: https://developer.r-project.org/
-- version_line: 4.2.x
-  name: r
-  date: 2023-04-01
-  link: https://developer.r-project.org/
 dependencies:
 - name: r
   version: 3.6.2


### PR DESCRIPTION
The deprecation dates in the manifest.yml of R Buildpack are mere guesswork. R does not seem to officially announce End-of-Support dates. Removing them will help stop propagating wrong/useless info.