### PR TITLE
Bumps disk space to get test to pass

### DIFF
--- a/src/r/integration/rserve_test.go
+++ b/src/r/integration/rserve_test.go
@@ -28,7 +28,7 @@ var _ = Describe("CF R Buildpack", func() {
 			}
 			app = cutlass.New(filepath.Join(bpDir, "fixtures", "rserve_supply"))
 			app.Buildpacks = []string{"r_buildpack", "https://github.com/cloudfoundry/python-buildpack#master"}
-			app.Disk = "1G"
+			app.Disk = "2G"
 		})
 
 		It("pythons uses Rserve", func() {


### PR DESCRIPTION
* A short explanation of the proposed change:
The tests have been failing because the disk fills up during staging. This will increase the disk size to allow the tests to pass once again.

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [ ] I have added an integration test
