### PR TITLE
pass stack to packaging script

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -105,7 +105,7 @@ function specs::run() {
   fi
 
   local buildpack_file
-  buildpack_file="$(buildpack::package "1.2.3" "${cached}")"
+  buildpack_file="$(buildpack::package "1.2.3" "${cached}" "${stack}")"
 
   CF_STACK="${stack}" \
   BUILDPACK_FILE="${BUILDPACK_FILE:-"${buildpack_file}"}" \
@@ -127,13 +127,14 @@ function buildpack::package() {
   local version cached
   version="${1}"
   cached="${2}"
+  stack="${3}"
 
   local name cached_flag
-  name="buildpack-v${version}-uncached.zip"
+  name="buildpack-${stack}-v${version}-uncached.zip"
   cached_flag=""
   if [[ "${cached}" == "true" ]]; then
     cached_flag="--cached"
-    name="buildpack-v${version}-cached.zip"
+    name="buildpack-${stack}-v${version}-cached.zip"
   fi
 
   local output
@@ -142,6 +143,7 @@ function buildpack::package() {
   bash "${ROOTDIR}/scripts/package.sh" \
     --version "${version}" \
     --output "${output}" \
+    --stack "${stack}" \
     "${cached_flag}" > /dev/null
 
   printf "%s" "${output}"


### PR DESCRIPTION
See the [pipeline
tests](https://buildpacks.ci.cf-app.com/teams/main/pipelines/r-buildpack/jobs/specs-edge-integration-develop-cflinuxfs3/builds/26#L634bb46e:161), it looks like the integration-test script packages an "any" stack buildpack comprising deps of all stacks thus going over the 1G buildpack limit.

See https://github.com/cloudfoundry/buildpacks-github-config/pull/11 where the same question is discussed.