### PR TITLE
Cleanup manifest.yml to keep latest available version of dependencies

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -79,56 +79,6 @@ dependencies:
     source: https://cran.r-project.org/src/contrib/shiny_1.8.0.tar.gz
     source_sha256: f28740ba28707e8b3dabb2ad27b002dae555317010660702163bb0daefe04641
 - name: r
-  version: 4.3.1
-  uri: https://buildpacks.cloudfoundry.org/dependencies/r/r_4.3.1_linux_noarch_cflinuxfs3_ddda7fbf.tgz
-  sha256: ddda7fbf9121299d95da5a17baf7c4d5bde3363efe89877e2ec6abd8c6c6be3d
-  cf_stacks:
-  - cflinuxfs3
-  source: https://cran.r-project.org/src/base/R-4/R-4.3.1.tar.gz
-  source_sha256: 8dd0bf24f1023c6f618c3b317383d291b4a494f40d73b983ac22ffea99e4ba99
-  dependencies:
-  - name: forecast
-    version: 8.21.1
-    source: https://cran.r-project.org/src/contrib/forecast_8.21.1.tar.gz
-    source_sha256: 811eace27c7f6e99e1048b8f2522e67bb3620471c5431e0ef83c396612dc8127
-  - name: plumber
-    version: 1.2.1
-    source: https://cran.r-project.org/src/contrib/plumber_1.2.1.tar.gz
-    source_sha256: 6ffc13e5ce1ff7ec81f6a4ab04eb1cb9f6da4004cf205ba3098d2ec4a83f1ecc
-  - name: rserve
-    version: 1.8.11
-    source: https://cran.r-project.org/src/contrib/Rserve_1.8-11.tar.gz
-    source_sha256: 9dfb1d68493f8cee5d2e12a1bfa604404834e11809f4c908d65b9100a9af1b85
-  - name: shiny
-    version: 1.7.5
-    source: https://cran.r-project.org/src/contrib/shiny_1.7.5.tar.gz
-    source_sha256: eddb971b22e634b78ee24829f5fe6d2f7f87ec38538a93fdfedc45a706928a40
-- name: r
-  version: 4.3.1
-  uri: https://buildpacks.cloudfoundry.org/dependencies/r/r_4.3.1_linux_noarch_cflinuxfs4_58b762cf.tgz
-  sha256: 58b762cfe6095ffa50d1a67e95b2636aa82b0d401a0b23eb941d457cd05a3e97
-  cf_stacks:
-  - cflinuxfs4
-  source: https://cran.r-project.org/src/base/R-4/R-4.3.1.tar.gz
-  source_sha256: 8dd0bf24f1023c6f618c3b317383d291b4a494f40d73b983ac22ffea99e4ba99
-  dependencies:
-  - name: forecast
-    version: 8.21.1
-    source: https://cran.r-project.org/src/contrib/forecast_8.21.1.tar.gz
-    source_sha256: 811eace27c7f6e99e1048b8f2522e67bb3620471c5431e0ef83c396612dc8127
-  - name: plumber
-    version: 1.2.1
-    source: https://cran.r-project.org/src/contrib/plumber_1.2.1.tar.gz
-    source_sha256: 6ffc13e5ce1ff7ec81f6a4ab04eb1cb9f6da4004cf205ba3098d2ec4a83f1ecc
-  - name: rserve
-    version: 1.8.11
-    source: https://cran.r-project.org/src/contrib/Rserve_1.8-11.tar.gz
-    source_sha256: 9dfb1d68493f8cee5d2e12a1bfa604404834e11809f4c908d65b9100a9af1b85
-  - name: shiny
-    version: 1.7.5
-    source: https://cran.r-project.org/src/contrib/shiny_1.7.5.tar.gz
-    source_sha256: eddb971b22e634b78ee24829f5fe6d2f7f87ec38538a93fdfedc45a706928a40
-- name: r
   version: 4.3.2
   uri: https://buildpacks.cloudfoundry.org/dependencies/r/r_4.3.2_linux_noarch_cflinuxfs3_ab9e89ff.tgz
   sha256: ab9e89ff1dd2587b18e6a5c9bb84b539bf39e2045112daf33802f013fcd259eb


### PR DESCRIPTION
It seems that issue #219 still occurs when introducing a new version for `4.3.x`. It's essential to address this issue consistently whenever we add a new version for `4.3.x`. Consider investigating the root cause and exploring why the [change](https://github.com/cloudfoundry/buildpacks-ci/blob/a9bbe8aad864c1f7475b6a9a49daad1801213a2a/pipelines/config/dependency-builds.yml#L318) to the `dependency-builds` logic to retain only the latest version is not working.

![Screenshot 2023-11-20 at 12:05:52 PM](https://github.com/cloudfoundry/r-buildpack/assets/17348387/097dff6f-23f2-4e26-96f7-500a233102bc)
