### PR TITLE
fixts/rserve: pyRserve isn't compatible w latest numpy2

### DIFF
--- a/fixtures/rserve_supply/requirements.txt
+++ b/fixtures/rserve_supply/requirements.txt
@@ -1,1 +1,2 @@
+numpy==1.26.4 #pyRserve as of date isn't compatible with numpy2.0
 pyRserve


### PR DESCRIPTION
The CI failures coincide with the release of
numpy2 on Jun 16, 2024. https://pypi.org/project/numpy/#history

https://buildpacks.ci.cf-app.com/teams/main/pipelines/r-buildpack/jobs/specs-edge-integration-develop-cflinuxfs4/builds/65